### PR TITLE
Implement Ukrainian and Russian languages transliteration

### DIFF
--- a/VRCSubs/Config.yml
+++ b/VRCSubs/Config.yml
@@ -1,5 +1,5 @@
 # Set this to true in order to pause the subtitling when your in-game microphone is muted
 FollowMicMute: false
 
-# Change this to your language if you don't want to speak english
+# Change this to your language if you don't want to speak English. Uses ISO language codes (see http://www.lingoes.net/en/translator/langcode.htm), e.g. en-US, fr-FR, uk-UA
 CapturedLanguage: "en-US"

--- a/VRCSubs/Requirements.txt
+++ b/VRCSubs/Requirements.txt
@@ -1,4 +1,5 @@
 pyaudio
 SpeechRecognition
 python-osc
+cyrtranslit
 pyyaml

--- a/VRCSubs/vrcsubs.py
+++ b/VRCSubs/vrcsubs.py
@@ -5,6 +5,7 @@ VRCSubs - A script to create "subtitles" for yourself using the VRChat textbox!
 
 import queue, threading, datetime, os, time, textwrap
 import speech_recognition as sr
+import cyrtranslit
 from speech_recognition import UnknownValueError, WaitTimeoutError, AudioData
 from pythonosc import udp_client
 from pythonosc.dispatcher import Dispatcher
@@ -96,7 +97,13 @@ def process_sound():
             current_text = textwrap.wrap(current_text, width=144)[-1]
 
         last_disp_time = datetime.datetime.now()
-        
+        if config["CapturedLanguage"] == "ru-RU":
+            current_text = cyrtranslit.to_latin(current_text, "ru")
+        elif config["CapturedLanguage"] == "uk-UA":
+            current_text = cyrtranslit.to_latin(current_text, "ua")
+        else:
+            current_text = current_text
+
         client.send_message("/chatbox/input", [current_text, True])
         print("[ProcessThread] Recognized:",current_text)
 
@@ -191,11 +198,11 @@ def main():
     
     osc = None
     if config['FollowMicMute']:
-        print("[VRCSubs] FollowMicMute is enabled in the config, speech recognition will pause when your mic is muted ingame!")
+        print("[VRCSubs] FollowMicMute is enabled in the config, speech recognition will pause when your mic is muted in-game!")
         osc = OSCServer()
         osc.launch()
     else:
-        print("[VRCSubs] FollowMicMute is NOT enabled in the config, speech recognition will work even while muted ingame!")
+        print("[VRCSubs] FollowMicMute is NOT enabled in the config, speech recognition will work even while muted in-game!")
 
     pst.join()
     cat.join()


### PR DESCRIPTION
Since VRChat's chat box OSC input is ASCII-only, in order to use Ukrainian and Russian languages through this script we need to transliterate them (convert from cyryllic to latin letters). I did that with a simple Language check before the `send_message` event and a `cyrtranslit` library to do the entire task for us. 