### PR TITLE
UTF-8 Chatbox Support

### DIFF
--- a/RunVRCNowPlaying.bat
+++ b/RunVRCNowPlaying.bat
@@ -1,5 +1,5 @@
 @echo off
 echo "Installing requirements (be sure to have python installed and in PATH)"
-pip install -r VRCNowPlaying/Requirements_nocutlet.txt
+pip install -r VRCNowPlaying/Requirements.txt
 python VRCNowPlaying/vrcnowplaying.py
 pause

--- a/VRCNowPlaying/Config.yml
+++ b/VRCNowPlaying/Config.yml
@@ -1,5 +1,5 @@
 # Configure what is shown while you're listening to a song. Use {song_artist}, {song_title}, and {song_position} as placeholders.
-DisplayFormat: "( NP: {song_artist} - {song_title}{song_position} )"
+DisplayFormat: "( ▶️ {song_artist} - {song_title}{song_position} )"
 
 # Configure what is shown when you pause media.
-PausedFormat: "( Playback Paused )"
+PausedFormat: "( ⏸️ Playback Paused )"

--- a/VRCNowPlaying/Requirements.txt
+++ b/VRCNowPlaying/Requirements.txt
@@ -1,7 +1,4 @@
 python-osc
 asyncio
-cutlet
-unidic-lite
 winsdk
 pyyaml
-unidecode

--- a/VRCNowPlaying/Requirements_nocutlet.txt
+++ b/VRCNowPlaying/Requirements_nocutlet.txt
@@ -1,5 +1,0 @@
-python-osc
-asyncio
-winsdk
-pyyaml
-unidecode

--- a/VRCSubs/Requirements.txt
+++ b/VRCSubs/Requirements.txt
@@ -1,8 +1,5 @@
 pyaudio
 SpeechRecognition
 python-osc
-cyrtranslit
-unidecode
 pyyaml
 googletrans==4.0.0rc1
-pykakasi

--- a/VRCSubs/vrcsubs.py
+++ b/VRCSubs/vrcsubs.py
@@ -5,9 +5,6 @@ VRCSubs - A script to create "subtitles" for yourself using the VRChat textbox!
 
 import queue, threading, datetime, os, time, textwrap
 import speech_recognition as sr
-import cyrtranslit
-import unidecode
-import pykakasi
 from googletrans import Translator
 from speech_recognition import UnknownValueError, WaitTimeoutError, AudioData
 from pythonosc import udp_client
@@ -95,7 +92,6 @@ def process_sound():
         if difference.total_seconds() < 1 and not final:
             continue
         
-
         try:
             #client.send_message("/chatbox/typing", True)
             text = r.recognize_google(ad, language=config["CapturedLanguage"])
@@ -141,27 +137,6 @@ def process_sound():
             current_text = textwrap.wrap(current_text, width=144)[-1]
 
         last_disp_time = datetime.datetime.now()
-       
-
-        textChanged = False
-
-        if textDispLangage == "ru-RU":
-            textChanged = True
-            current_text = cyrtranslit.to_latin(current_text, "ru")
-        elif textDispLangage == "uk-UA":
-            textChanged = True
-            current_text = cyrtranslit.to_latin(current_text, "ua")
-        elif strip_dialect(textDispLangage) == "ja":
-            textChanged = True
-            kks = pykakasi.kakasi()
-            conv = kks.convert(current_text)
-            current_text = ' '.join([part['hepburn'] for part in conv])
-        elif not current_text.isascii():
-            textChanged = True
-            current_text = unidecode.unidecode_expect_nonascii(current_text)
-
-        if textChanged:
-            print("[ProcessThread] Converted to ascii:", current_text)
 
         client.send_message("/chatbox/input", [current_text, True])
 


### PR DESCRIPTION
This PR can be merged after VRChat pushes b1258 to Live. It will allow non-ascii characters to be sent. Fixes #1 

![VRCNowPlaying UTF-8](https://assets.cyberkitsune.net/share/VRChat_qeQqGsviLk.png)
![VRCSubs UTF-8](https://assets.cyberkitsune.net/share/VRChat_i4NHuHc9OU.png)

- [X] Remove deps for `unidecode`, `cutlet`, etc.
- [X] Remove multi-language unicode decoding from VRCSubs and VRCNowPlaying
- [X] Check and Remove any now-unused code related to unidecode
- [X] Test in VRChat Open beta
- [x] Wait for VRChat to release build 1258 to live