### PR TITLE
[VRCSubs] Split translation logic into abstract base classes

### DIFF
--- a/VRCSubs/Config.yml
+++ b/VRCSubs/Config.yml
@@ -15,7 +15,7 @@ EnableTranslation: false
 
 # For message translation, specify what translation engine to use. The options are:
 # "Google" - The default, free
-# "DeepL"  - More accurate then Google Translate, but costs money and supports fewer langugages. It requires a token. (see below)
+# "DeepL"  - More accurate then Google Translate, but supports fewer langugages. It requires a token. (see below)
 #            List of supported languages by DeepL: https://www.deepl.com/ja/docs-api/translate-text/translate-text/
 TranslateMethod: "Google"
 

--- a/VRCSubs/Config.yml
+++ b/VRCSubs/Config.yml
@@ -13,6 +13,17 @@ CapturedLanguage: "en-US"
 # If you wish your chat to be translated (very beta feature!) set this to true.
 EnableTranslation: false
 
+# For message translation, specify what translation engine to use. The options are:
+# "Google" - The default, free
+# "DeepL"  - More accurate then Google Translate, but costs money and supports fewer langugages. It requires a token. (see below)
+#            List of supported languages by DeepL: https://www.deepl.com/ja/docs-api/translate-text/translate-text/
+TranslateMethod: "Google"
+
+# If your translation service requires a token, specify it here.
+# For "Google" - No token required, leave as ""
+# For "DeepL"  - You need to register at DeepL and get the API https://www.deepl.com/ja/account/summary
+TranslateToken: ""
+
 # If EnableTranslation is true, set this to the language you wish to translate your speech to. Not all languages are supported.
 # /!\ Warning: VRChat does not support non-latin characters over OSC so langages that use non-latin characters will be converted.
 TranslateTo: "es-MX"
@@ -25,10 +36,3 @@ TranslateInterumResults: true
 
 # This config option should always be false. Used with OSC Control. Please do not touch! ^^
 Pause: false
-
-# If you want to translate using DeepL set this to true.
-# It is more accurate than Google Translate, although it supports fewer languages.
-# To use it, you need to register at DeepL and get the API https://www.deepl.com/ja/account/summary
-# List of supported languages https://www.deepl.com/ja/docs-api/translate-text/translate-text/
-DeepL: false
-DeepLToken: ""

--- a/VRCSubs/translators.py
+++ b/VRCSubs/translators.py
@@ -1,0 +1,84 @@
+import abc
+import deepl
+import googletrans
+
+registered_translators = {}
+
+class VRCSubsTranslator(metaclass=abc.ABCMeta):
+    @abc.abstractclassmethod
+    def __init__(self, args) -> None:
+        pass
+
+    @abc.abstractclassmethod
+    def translate(self, source_lang, target_lang, text) -> str:
+        pass
+
+    @abc.abstractclassmethod
+    def conv_langcode(self, langcode) -> str:
+        return langcode
+
+
+class RegisterTranslator(object):
+
+    def __init__(self, translator_name):
+        self.translator_name = translator_name
+
+    def __call__(self, translator_class):
+        global registered_translators
+        registered_translators[self.translator_name] = translator_class
+
+
+@RegisterTranslator("Google")
+class GoogleTranslator(VRCSubsTranslator):
+    def __init__(self, args):
+        self.translator = googletrans.Translator()
+
+    def conv_langcode(self, langcode) -> str:
+        langsplit = langcode.split('-')[0]
+        if langsplit == "zh":
+            if langcode == "zh-CN":
+                return langcode
+            return "zh-TW"
+        if langsplit == "yue":
+            return "zh-TW"
+
+        return langsplit
+
+    def translate(self, source_lang, target_lang, text):
+        output = None
+        try:
+            output = self.translator.translate(text=text, src=self.conv_langcode(source_lang), dest=self.conv_langcode(target_lang))
+        except Exception as e:
+            raise Exception("Failed to translate text!", e)
+        
+        if output is not None:
+            return output.text
+        else:
+            return None
+
+
+@RegisterTranslator("DeepL")
+class DeepLTranslator(VRCSubsTranslator):
+    def __init__(self, api_key):
+        self.dtranslator = None
+        try:
+            self.dtranslator = deepl.Translator(api_key)
+        except deepl.exceptions.DeepLException as e:
+            raise Exception("Failed to initalize DeepL!", e)
+
+    def conv_langcode(self, langcode) -> str:
+        if langcode.upper() in ["EN-US","EN-GB","PT-BR","PT-PT"]:
+            return langcode.upper()
+        else:
+            return langcode.split('-')[0]
+
+    def translate(self, source_lang, target_lang, text) -> str:
+        output = None
+        try:
+            self.dtranslator.translate_text(text=text, source_lang=self.conv_langcode(source_lang)[:2].upper(), target_lang=self.conv_langcode(target_lang)[:2].upper())
+        except Exception as e:
+            raise Exception("Failed to translate text!", e)
+        if output is not None:
+            return output.text
+        else:
+            return None

--- a/VRCSubs/translators.py
+++ b/VRCSubs/translators.py
@@ -106,7 +106,7 @@ class DeepLTranslator(VRCSubsTranslator):
     def translate(self, source_lang, target_lang, text) -> str:
         output = None
         try:
-            self.dtranslator.translate_text(text=text, source_lang=self.conv_langcode(source_lang)[:2].upper(), target_lang=self.conv_langcode(target_lang)[:2].upper())
+            output = self.dtranslator.translate_text(text=text, source_lang=self.conv_langcode(source_lang)[:2].upper(), target_lang=self.conv_langcode(target_lang).upper())
         except Exception as e:
             raise Exception("Failed to translate text!", e)
         if output is not None:

--- a/VRCSubs/translators.py
+++ b/VRCSubs/translators.py
@@ -5,22 +5,53 @@ import googletrans
 registered_translators = {}
 
 class VRCSubsTranslator(metaclass=abc.ABCMeta):
+    """An abstract class that represents a possible translator for VRCSubs. Subclass this abstract class to make one
+    """
     @abc.abstractclassmethod
-    def __init__(self, args) -> None:
+    def __init__(self, args):
+        """Constructs a VRCSubs translator and initalizes it.
+
+        Args:
+            args (str): If the translator requires any string arguments, such as an api key, specify them here.
+        """
         pass
 
     @abc.abstractclassmethod
     def translate(self, source_lang, target_lang, text) -> str:
+        """Translate given text from a given langage into a different one.
+
+        Args:
+            source_lang (str): The language code of the source language (unaltered)
+            target_lang (str): The langugage code of the destination language (unaltered)
+            text (str): The untranslated text
+
+        Returns:
+            str: The translated text
+        """
         pass
 
     @abc.abstractclassmethod
     def conv_langcode(self, langcode) -> str:
+        """Convert a standard language code into one supported by this translator.
+
+        Args:
+            langcode (str): The standard language code
+
+        Returns:
+            str: The translator-specific language code
+        """
         return langcode
 
 
 class RegisterTranslator(object):
-
+    """This is a decorator that must be attached to your subclass of VRCSubsTranslator for the config file to be aware that it exists.
+    """
     def __init__(self, translator_name):
+        """Creates a translator registration for a CLASS
+
+        Args:
+            translator_name (str): The name of your translator as it will be set in the Config.yml
+        """
         self.translator_name = translator_name
 
     def __call__(self, translator_class):


### PR DESCRIPTION
This PR moves most of the translator specific code out of `VRCSubs.py` and into `translators.py` in order to reduce clutter in the main script.

It adds a base abstract base class that can be used to add more translation engines in the future without modifying the main script.

Additionally, you now specify in the config file by string which translator service to use

I was unable to test if DeepL still works after the changes as I do not have an API key. @0kq-github could you please pull this pull request locally to test? 💛

## todo before merge
- [X] Check Google Translate still works
- [x] Check DeepL still works (cc: @0kq-github)
- [x] Add docstrings to `VRCSubsTranslator` abstract base class