### PR TITLE
Fix assumption that python links to python3

### DIFF
--- a/RunVRCNowPlaying.bat
+++ b/RunVRCNowPlaying.bat
@@ -1,6 +1,6 @@
 @echo off
 call UpdateScripts.bat
 echo "Installing requirements (be sure to have python installed and in PATH)"
-pip install -r VRCNowPlaying/Requirements.txt
-python VRCNowPlaying/vrcnowplaying.py
+pip3 install -r VRCNowPlaying/Requirements.txt
+python3 VRCNowPlaying/vrcnowplaying.py
 pause

--- a/RunVRCSubs.bat
+++ b/RunVRCSubs.bat
@@ -1,6 +1,6 @@
 @echo off
 call UpdateScripts.bat
 echo "Installing requirements (be sure to have python installed and in PATH)"
-pip install -r VRCSubs/Requirements.txt
-python VRCSubs/vrcsubs.py
+pip3 install -r VRCSubs/Requirements.txt
+python3 VRCSubs/vrcsubs.py
 pause

--- a/UpdateScripts.bat
+++ b/UpdateScripts.bat
@@ -1,4 +1,4 @@
 @echo off
 echo "Checking for updates..."
-pip install -r Requirements.txt
-python Updatecheck.py
+pip3 install -r Requirements.txt
+python3 Updatecheck.py


### PR DESCRIPTION
Currently, the .bat files assume that the `python` command links to `python3` while on many systems, it might link to python2

This pull request fixes that behavior 