### PR TITLE
Option to Remove Language Indicator (When translate is enabled)

### DIFF
--- a/VRCSubs/Config.yml
+++ b/VRCSubs/Config.yml
@@ -44,5 +44,8 @@ TranslateTo: "es-MX"
 # Only leave this on if you're ok with your translation being very incorrect due to missing context.
 TranslateInterumResults: true
 
+# Turn this to false to hide the translation languages (the "[en-US -> es-MX]") from the chatbox
+ShowTranslateIndicator: true
+
 # This config option should always be false. Used with OSC Control. Please do not touch! ^^
 Pause: false

--- a/VRCSubs/vrcsubs.py
+++ b/VRCSubs/vrcsubs.py
@@ -20,6 +20,8 @@ except ImportError:
 
 config = {
     'FollowMicMute': True, 
+    'AllowOSCControl': True, 
+    'OSCControlPort': 9001,
     'CapturedLanguage': "en-US", 
     'TranscriptionMethod': "Google", 
     'TranscriptionRateLimit': 1200,
@@ -27,10 +29,9 @@ config = {
     'TranslateMethod': "Google", 
     'TranslateToken': "", 
     "TranslateTo": "en-US", 
-    'AllowOSCControl': True, 
-    'Pause': False, 
     'TranslateInterumResults': True, 
-    'OSCControlPort': 9001
+    'ShowTranslateIndicator': True,
+    'Pause': False
     }
 state = {'selfMuted': False}
 state_lock = threading.Lock()
@@ -147,7 +148,8 @@ def process_sound():
             try:
                 trans = translator.translate(source_lang=config["CapturedLanguage"], target_lang=config["TranslateTo"], text=current_text)
                 origin = current_text
-                current_text = trans + " [%s->%s]" % (config["CapturedLanguage"], config["TranslateTo"])
+                if config['ShowTranslateIndicator']:
+                    current_text = trans + " [%s->%s]" % (config["CapturedLanguage"], config["TranslateTo"])
                 
                 print("[ProcessThread] Recognized:",origin, "->", current_text)
             except Exception as e:

--- a/VRCSubs/vrcsubs.py
+++ b/VRCSubs/vrcsubs.py
@@ -150,6 +150,8 @@ def process_sound():
                 origin = current_text
                 if config['ShowTranslateIndicator']:
                     current_text = trans + " [%s->%s]" % (config["CapturedLanguage"], config["TranslateTo"])
+                else:
+                    current_text = trans
                 
                 print("[ProcessThread] Recognized:",origin, "->", current_text)
             except Exception as e:


### PR DESCRIPTION
This PR adds a new config option to VRCSubs that lets you remove the translate indicator (the `[en-US->es-MX]`) from the chatbox.