### PR TITLE
Make logging format consistent, de-clutter.

### DIFF
--- a/RunVRCNowPlaying.bat
+++ b/RunVRCNowPlaying.bat
@@ -1,6 +1,6 @@
 @echo off
 call UpdateScripts.bat
-echo "Installing requirements (be sure to have python installed and in PATH)"
-python -m pip install -r VRCNowPlaying/Requirements.txt
+echo [%~n0] Installing requirements (be sure to have python installed and in PATH)
+python -m pip install -r VRCNowPlaying/Requirements.txt -q
 python VRCNowPlaying/vrcnowplaying.py
 pause

--- a/RunVRCSubs.bat
+++ b/RunVRCSubs.bat
@@ -1,6 +1,6 @@
 @echo off
 call UpdateScripts.bat
-echo "Installing requirements (be sure to have python installed and in PATH)"
-python -m pip install -r VRCSubs/Requirements.txt
+echo [%~n0] Installing requirements (be sure to have python installed and in PATH)
+python -m pip install -r VRCSubs/Requirements.txt -q
 python VRCSubs/vrcsubs.py
 pause

--- a/UpdateScripts.bat
+++ b/UpdateScripts.bat
@@ -1,4 +1,4 @@
 @echo off
-echo "Checking for updates..."
-python -m pip install -r Requirements.txt
+echo [%~n0] Checking for updates...
+python -m pip install -r Requirements.txt -q
 python Updatecheck.py


### PR DESCRIPTION
Simple PR, but it makes the logs a bit nicer and consistent.
I removed the quotes on the echo statements as they get logged and look bad, while also adding the file's name in brackets to be consistent with the logs generated by the Python scripts. Also pip is quieted so it won't print any informational logs, this is to avoid cluttering the console with text that doesn't need to be there. It should still log anything more severe than info like warnings. Unsure if it will log during initial install process, however, it may just be silent while that happens.

Small explainer for the bracket nonsense:
Batch arguments thankfully behave exactly as I thought they did, the 0th argument contains the file itself being executed, so `%~n0` expands to just the file name of argument zero, without quotes. See `call /?` in CMD for an explanation of the awfulness that is MS Batch argument handling.
Also, quotes are printed literally when not otherwise stripped out by the parser, as they are not special characters. Good luck if you need to print a percent symbol or special ASCII control codes in pure MS Batch though! ;P