### PR TITLE
Add script to detect Python and install it if not

### DIFF
--- a/CheckPython.bat
+++ b/CheckPython.bat
@@ -1,6 +1,6 @@
 @echo off
-python --help >nul 2>&1
 Setlocal EnableDelayedExpansion
+python --help >nul 2>&1
 IF !ERRORLEVEL! NEQ 0 (
     WHERE winget
     IF !ERRORLEVEL! NEQ 0 (

--- a/CheckPython.bat
+++ b/CheckPython.bat
@@ -1,0 +1,18 @@
+@echo off
+python --help >nul 2>&1
+Setlocal EnableDelayedExpansion
+IF !ERRORLEVEL! NEQ 0 (
+    WHERE winget
+    IF !ERRORLEVEL! NEQ 0 (
+        echo "It appears you do not have Python installed! Please install Python 3.9 or higher from python.org or the Microsoft Store."
+        pause
+        exit
+    ) ELSE (
+        choice /C:yn /m "You do not have Python installed. Do you wish to install it? [Y] / [N]"
+        if !ERRORLEVEL! == 1 (
+            winget install python
+        )
+    )
+) ELSE (
+    echo "Python is installed!"
+)

--- a/CheckPython.bat
+++ b/CheckPython.bat
@@ -1,25 +1,25 @@
 @echo off
 Setlocal EnableDelayedExpansion
-python --help >nul 2>&1
-IF !ERRORLEVEL! NEQ 0 (
+python CheckPython.py >nul 2>&1
+IF !ERRORLEVEL! NEQ 3 (
     WHERE winget
     IF !ERRORLEVEL! NEQ 0 (
-        echo "It appears you do not have Python installed! Please install Python 3.9 or higher from python.org or the Microsoft Store."
+        echo It appears you do not have Python installed! Please install Python 3.9 or higher from python.org or the Microsoft Store.
         pause
         exit
     ) ELSE (
         choice /C:yn /m "You do not have Python installed. Do you wish to install it? [Y] / [N]"
         if !ERRORLEVEL! == 1 (
-            echo "Please accept any licence agreements after this to install python by pressing Y then enter."
+            echo Please accept any licence agreements after this to install python by pressing Y then enter.
             winget install python
             if !ERRORLEVEL! NEQ 0 (
-                echo "For some reason Python failed to install with winget, install Python manually with the windows store or using python.org"
-                echo "Feel free to contact the vrc-osc-scripts Discord for more help"
+                echo For some reason Python failed to install with winget, install Python manually with the windows store or using python.org
+                echo Feel free to contact the vrc-osc-scripts Discord for more help.
                 pause
                 exit
             )
         )
     )
 ) ELSE (
-    echo "Python is installed!"
+    echo Python is installed!
 )

--- a/CheckPython.bat
+++ b/CheckPython.bat
@@ -10,7 +10,14 @@ IF !ERRORLEVEL! NEQ 0 (
     ) ELSE (
         choice /C:yn /m "You do not have Python installed. Do you wish to install it? [Y] / [N]"
         if !ERRORLEVEL! == 1 (
+            echo "Please accept any licence agreements after this to install python by pressing Y then enter."
             winget install python
+            if !ERRORLEVEL! NEQ 0 (
+                echo "For some reason Python failed to install with winget, install Python manually with the windows store or using python.org"
+                echo "Feel free to contact the vrc-osc-scripts Discord for more help"
+                pause
+                exit
+            )
         )
     )
 ) ELSE (

--- a/CheckPython.py
+++ b/CheckPython.py
@@ -1,0 +1,4 @@
+# This script returns 3. 
+
+if __name__ == "__main__":
+    exit(3)

--- a/RunVRCNowPlaying.bat
+++ b/RunVRCNowPlaying.bat
@@ -1,4 +1,5 @@
 @echo off
+call CheckPython.bat
 call UpdateScripts.bat
 echo "Installing requirements (be sure to have python installed and in PATH)"
 python -m pip install -r VRCNowPlaying/Requirements.txt

--- a/RunVRCSubs.bat
+++ b/RunVRCSubs.bat
@@ -1,4 +1,5 @@
 @echo off
+call CheckPython.bat
 call UpdateScripts.bat
 echo "Installing requirements (be sure to have python installed and in PATH)"
 python -m pip install -r VRCSubs/Requirements.txt


### PR DESCRIPTION
This PR adds a new batch script that will:

* Run a python test script that ideally should exit with code 3
* If it doesn't, we assume python is broken / not installed
* If python isn't installed, we use `winget` (if present) to try and install it off of the windows store.

So far this has worked for me in a Windows 10 VM. Looking for feedback before merging this though, really wanna see if it falls down on other systems. Feel free to cherry pick or download from the branch [here](https://github.com/cyberkitsune/vrc-osc-scripts/tree/feat/python-install-helper) (you will need to make a folder called .git to pevent it from auto-updating) to test it.