### PR TITLE
VRCNowPlaying: Output avatar parameter

### DIFF
--- a/VRCNowPlaying/vrcnowplaying.py
+++ b/VRCNowPlaying/vrcnowplaying.py
@@ -154,9 +154,11 @@ def main():
                 print("[VRCNowPlaying]", current_song_string)
             if send_to_vrc:
                 client.send_message("/chatbox/input", [current_song_string, True, False])
+                client.send_message("/avatar/parameters/VRCNP-Playing", True)
             lastPaused = False
         elif current_media_info['status'] == GlobalSystemMediaTransportControlsSessionPlaybackStatus.PAUSED and not lastPaused:
             client.send_message("/chatbox/input", [config['PausedFormat'], True, False])
+            client.send_message("/avatar/parameters/VRCNP-Playing", False)
             print("[VRCNowPlaying]", config['PausedFormat'])
             last_displayed_song = ("", "")
             lastPaused = True


### PR DESCRIPTION
One-commit pull request, output the current media playing status to the vrchat avatar paramater `VRCNP-Playing` (bool)

Currently does not support the textfile watcher mode (I may change this later)

Should fix #19 ^^