### PR TITLE
OSCQuery Support (VRCSubs)

### DIFF
--- a/VRCSubs/Config.yml
+++ b/VRCSubs/Config.yml
@@ -4,6 +4,9 @@ FollowMicMute: false
 # Set this to allow any of these config options to be driven by avatar paramaters. This will cause the script to listen for OSC events.
 AllowOSCControl: true
 
+# This setting changes which port VRCSubs listens on in order to receive OSC messages. You only need to change it if you use an OSC aggregator.
+OSCControlPort: 9001
+
 # Change this to your language if you don't want to speak English. Uses ISO language codes (see http://www.lingoes.net/en/translator/langcode.htm), e.g. en-US, fr-FR, uk-UA
 CapturedLanguage: "en-US"
 

--- a/VRCSubs/Config.yml
+++ b/VRCSubs/Config.yml
@@ -4,9 +4,6 @@ FollowMicMute: false
 # Set this to allow any of these config options to be driven by avatar paramaters. This will cause the script to listen for OSC events.
 AllowOSCControl: true
 
-# This setting changes which port VRCSubs listens on in order to receive OSC messages. You only need to change it if you use an OSC aggregator.
-OSCControlPort: 9001
-
 # Change this to your language if you don't want to speak English. Uses ISO language codes (see http://www.lingoes.net/en/translator/langcode.htm), e.g. en-US, fr-FR, uk-UA
 CapturedLanguage: "en-US"
 

--- a/VRCSubs/Requirements.txt
+++ b/VRCSubs/Requirements.txt
@@ -6,4 +6,4 @@ googletrans==4.0.0rc1
 deepl
 vosk
 pythonnet
-git+https://github.com/cyberkitsune/tinyoscquery.git
+https://github.com/cyberkitsune/tinyoscquery/archive/refs/tags/0.1.2.zip

--- a/VRCSubs/Requirements.txt
+++ b/VRCSubs/Requirements.txt
@@ -6,3 +6,4 @@ unidecode
 pyyaml
 googletrans==4.0.0rc1
 pykakasi
+pythonnet

--- a/VRCSubs/Requirements.txt
+++ b/VRCSubs/Requirements.txt
@@ -7,3 +7,4 @@ pyyaml
 googletrans==4.0.0rc1
 pykakasi
 pythonnet
+git+https://github.com/cyberkitsune/tinyoscquery.git

--- a/VRCSubs/vrcsubs.py
+++ b/VRCSubs/vrcsubs.py
@@ -8,12 +8,8 @@ import speech_recognition as sr
 import cyrtranslit
 import unidecode
 import pykakasi
-from pythonnet import load
-load("coreclr")
-import clr
-clr.AddReference(f"{os.path.dirname(os.path.realpath(__file__))}/vrc-oscquery-lib.dll")
-from VRC.OSCQuery import OSCQueryService
-from VRC.OSCQuery import Extensions
+from tinyoscquery.queryservice import OSCQueryService
+from tinyoscquery.utility import get_open_tcp_port, get_open_udp_port
 
 from googletrans import Translator
 from speech_recognition import UnknownValueError, WaitTimeoutError, AudioData
@@ -216,9 +212,9 @@ TODO: This maybe should be bundled into a class
 class OSCServer():
     def __init__(self):
         global config
-        self.osc_port = Extensions.GetAvailableUdpPort()
-        self.http_port = Extensions.GetAvailableTcpPort()
-        self.oscquery = OSCQueryService("VRCSubs-%i" % self.osc_port, self.http_port, self.osc_port, None)
+        self.osc_port = get_open_udp_port()
+        self.http_port = get_open_tcp_port()
+        self.oscquery = OSCQueryService("VRCSubs-%i" % self.osc_port, self.http_port, self.osc_port)
         print("[OSCQuery] Running on HTTP port", self.http_port, "and UDP port", self.osc_port)
 
         self.dispatcher = Dispatcher()

--- a/VRCSubs/vrcsubs.py
+++ b/VRCSubs/vrcsubs.py
@@ -20,7 +20,7 @@ except ImportError:
     from yaml import Loader
 
 
-config = {'FollowMicMute': True, 'CapturedLanguage': "en-US", 'EnableTranslation': False, "TranslateTo": "en-US", 'AllowOSCControl': True, 'Pause': False, 'TranslateInterumResults': True}
+config = {'FollowMicMute': True, 'CapturedLanguage': "en-US", 'EnableTranslation': False, "TranslateTo": "en-US", 'AllowOSCControl': True, 'Pause': False, 'TranslateInterumResults': True, 'OSCControlPort': 9001}
 state = {'selfMuted': False}
 state_lock = threading.Lock()
 
@@ -208,6 +208,7 @@ TODO: This maybe should be bundled into a class
 '''
 class OSCServer():
     def __init__(self):
+        global config
         self.dispatcher = Dispatcher()
         self.dispatcher.set_default_handler(self._def_osc_dispatch)
         self.dispatcher.map("/avatar/parameters/MuteSelf", self._osc_muteself)
@@ -215,7 +216,7 @@ class OSCServer():
         for key in config.keys():
             self.dispatcher.map("/avatar/parameters/vrcsub-%s" % key, self._osc_updateconf)
 
-        self.server = BlockingOSCUDPServer(("127.0.0.1", 9001), self.dispatcher)
+        self.server = BlockingOSCUDPServer(("127.0.0.1", config['OSCControlPort']), self.dispatcher)
         self.server_thread = threading.Thread(target=self._process_osc)
 
     def launch(self):

--- a/VRCSubs/vrcsubs.py
+++ b/VRCSubs/vrcsubs.py
@@ -33,8 +33,7 @@ config = {
     "TranslateTo": "en-US", 
     'AllowOSCControl': True, 
     'Pause': False, 
-    'TranslateInterumResults': True, 
-    'OSCControlPort': 9001
+    'TranslateInterumResults': True,
     }
 state = {'selfMuted': False}
 state_lock = threading.Lock()


### PR DESCRIPTION
This PR adds OSCQuery Support to VRCSubs. This means you can have OSC control (avatar parameters, mute, etc.) while running other scripts without using an OSC router.

Additionally, the script can now sync current variables at startup if you run it after the game.

Can somebody test / cherrypick this before I merge it? :)