### PR TITLE
VRCNowPlaying World Blacklist

### DIFF
--- a/VRCNowPlaying/Requirements.txt
+++ b/VRCNowPlaying/Requirements.txt
@@ -2,3 +2,4 @@ python-osc
 asyncio
 winsdk
 pyyaml
+requests

--- a/VRCNowPlaying/blacklist.py
+++ b/VRCNowPlaying/blacklist.py
@@ -1,0 +1,66 @@
+import threading, os, glob, time, re
+
+BLACKLISTED_WORLDS = {"wrld_b2d9f284-3a77-4a8a-a58e-f8427f87ba79": "Club Orion"}
+
+class NowPlayingWorldBlacklist():
+    def __init__(self):
+        self._last_world = ""
+        self._last_logfile = ""
+        self._log_monitor_thread = threading.Thread(target=self._do_log_monitor)
+        self._running = True
+        self._file = None
+
+        self._log_monitor_thread.start()
+        pass
+
+    def _get_latest_logfile(self):
+        lfglob = glob.glob(f"{os.getenv('USERPROFILE')}\\AppData\\LocalLow\\VRChat\\VRChat\\output_log_*.txt")
+
+        # Grab latest I think?
+        lfglob.sort(reverse=True)
+
+        return lfglob[0]
+
+    def _do_log_monitor(self):
+        print("[WorldBlacklist] Starting world monitor!")
+        while self._running:
+            # First, check if we're a new logfile. If we are, let's parse it and catch up.
+            if self._last_logfile != self._get_latest_logfile():
+                print(f"[Blacklist] New logfile! {self._get_latest_logfile()}")
+                if self._file is not None:
+                    self._file.close()
+                self._last_logfile = self._get_latest_logfile()
+                self._file = open(self._last_logfile, 'r', encoding="utf-8")
+
+                # Pass through all lines
+                for line in self._file.readlines():
+                    self._parse_logfile_line(line)
+
+                # All caught up, seek to end
+                self._file.seek(0, 2)
+
+                # Sleep a lil
+                time.sleep(0.1)
+                continue
+        
+            if self._file is not None:
+                line = self._file.readline()
+                if not line:
+                    time.sleep(0.1)
+                    continue
+
+                self._parse_logfile_line(line)
+
+
+    def _parse_logfile_line(self, line):
+        r = re.findall(r'Fetching world information for (wrld_.*)', line)
+        if len(r) > 0:
+           if self._last_world != r[0]:
+                print(f"[Blacklist] New world: {r[0]}")
+                self._last_world = r[0]
+
+    def is_current_blacklisted(self):
+        if self._last_world in BLACKLISTED_WORLDS:
+            return (True, BLACKLISTED_WORLDS[self._last_world])
+        
+        return (False, '')

--- a/VRCNowPlaying/blacklist.py
+++ b/VRCNowPlaying/blacklist.py
@@ -1,13 +1,5 @@
 import threading, os, glob, time, re, requests
 
-# Would be even cooler if we could just base this on tags, but that requires API, so oh well.
-#BLACKLISTED_WORLDS = {"wrld_b2d9f284-3a77-4a8a-a58e-f8427f87ba79": "Club Orion",
-#                      "wrld_23c9382b-24cd-4f4f-8f79-22900e93bc4e": "The Foundry Nightclub",
-#                      "wrld_33f38b4f-7f63-492e-93bb-801eb00fcaa7": "Poe's Nightclub",
-#                      "wrld_3ada5619-779c-41c3-b673-d5f842e19b2e": "Poe's Frightclub",
-#                      "wrld_b1ac17aa-cb4c-4aaf-a1e0-88e7252ddeac": "CLUB ORIGINS",
-#                      "wrld_f6377009-f666-4cbf-9270-bc1c70ec6de0": "Church of the Infinite Beat"}
-
 BLACKLIST_REPO = "https://github.com/cyberkitsune/chatbox-club-blacklist/raw/master/npblacklist.json"
 
 class NowPlayingWorldBlacklist():

--- a/VRCNowPlaying/blacklist.py
+++ b/VRCNowPlaying/blacklist.py
@@ -26,7 +26,6 @@ class NowPlayingWorldBlacklist():
         while self._running:
             # First, check if we're a new logfile. If we are, let's parse it and catch up.
             if self._last_logfile != self._get_latest_logfile():
-                print(f"[Blacklist] New logfile! {self._get_latest_logfile()}")
                 if self._file is not None:
                     self._file.close()
                 self._last_logfile = self._get_latest_logfile()
@@ -56,7 +55,6 @@ class NowPlayingWorldBlacklist():
         r = re.findall(r'Fetching world information for (wrld_.*)', line)
         if len(r) > 0:
            if self._last_world != r[0]:
-                print(f"[Blacklist] New world: {r[0]}")
                 self._last_world = r[0]
 
     def is_current_blacklisted(self):

--- a/VRCNowPlaying/blacklist.py
+++ b/VRCNowPlaying/blacklist.py
@@ -1,6 +1,11 @@
 import threading, os, glob, time, re
 
-BLACKLISTED_WORLDS = {"wrld_b2d9f284-3a77-4a8a-a58e-f8427f87ba79": "Club Orion"}
+# Would be even cooler if we could just base this on tags, but that requires API, so oh well.
+BLACKLISTED_WORLDS = {"wrld_b2d9f284-3a77-4a8a-a58e-f8427f87ba79": "Club Orion",
+                      "wrld_23c9382b-24cd-4f4f-8f79-22900e93bc4e": "The Foundry Nightclub",
+                      "wrld_33f38b4f-7f63-492e-93bb-801eb00fcaa7": "Poe's Nightclub",
+                      "wrld_3ada5619-779c-41c3-b673-d5f842e19b2e": "Poe's Frightclub",
+                      }
 
 class NowPlayingWorldBlacklist():
     def __init__(self):

--- a/VRCNowPlaying/blacklist.py
+++ b/VRCNowPlaying/blacklist.py
@@ -1,11 +1,14 @@
-import threading, os, glob, time, re
+import threading, os, glob, time, re, requests
 
 # Would be even cooler if we could just base this on tags, but that requires API, so oh well.
-BLACKLISTED_WORLDS = {"wrld_b2d9f284-3a77-4a8a-a58e-f8427f87ba79": "Club Orion",
-                      "wrld_23c9382b-24cd-4f4f-8f79-22900e93bc4e": "The Foundry Nightclub",
-                      "wrld_33f38b4f-7f63-492e-93bb-801eb00fcaa7": "Poe's Nightclub",
-                      "wrld_3ada5619-779c-41c3-b673-d5f842e19b2e": "Poe's Frightclub",
-                      }
+#BLACKLISTED_WORLDS = {"wrld_b2d9f284-3a77-4a8a-a58e-f8427f87ba79": "Club Orion",
+#                      "wrld_23c9382b-24cd-4f4f-8f79-22900e93bc4e": "The Foundry Nightclub",
+#                      "wrld_33f38b4f-7f63-492e-93bb-801eb00fcaa7": "Poe's Nightclub",
+#                      "wrld_3ada5619-779c-41c3-b673-d5f842e19b2e": "Poe's Frightclub",
+#                      "wrld_b1ac17aa-cb4c-4aaf-a1e0-88e7252ddeac": "CLUB ORIGINS",
+#                      "wrld_f6377009-f666-4cbf-9270-bc1c70ec6de0": "Church of the Infinite Beat"}
+
+BLACKLIST_REPO = "https://github.com/cyberkitsune/chatbox-club-blacklist/raw/master/npblacklist.json"
 
 class NowPlayingWorldBlacklist():
     def __init__(self):
@@ -14,9 +17,23 @@ class NowPlayingWorldBlacklist():
         self._log_monitor_thread = threading.Thread(target=self._do_log_monitor)
         self._running = True
         self._file = None
+        self._blacklisted_worlds = {}
 
         self._log_monitor_thread.start()
+        self._fetch_current_blacklist()
         pass
+
+    def _fetch_current_blacklist(self):
+        print("[WorldBlacklist] Fetching world blacklist...")
+        r = requests.get(BLACKLIST_REPO)
+        if r.status_code != 200:
+            raise Exception("Unable to fetch current blacklist!")
+        
+        js = r.json()
+        for world in js['worlds']:
+            self._blacklisted_worlds[world['id']] = world['name']
+
+        print(f"[WorldBlacklist] Loaded {len(self._blacklisted_worlds)} worldids.")
 
     def _get_latest_logfile(self):
         lfglob = glob.glob(f"{os.getenv('USERPROFILE')}\\AppData\\LocalLow\\VRChat\\VRChat\\output_log_*.txt")
@@ -63,7 +80,7 @@ class NowPlayingWorldBlacklist():
                 self._last_world = r[0]
 
     def is_current_blacklisted(self):
-        if self._last_world in BLACKLISTED_WORLDS:
-            return (True, BLACKLISTED_WORLDS[self._last_world])
+        if self._last_world in self._blacklisted_worlds:
+            return (True, self._blacklisted_worlds[self._last_world])
         
         return (False, '')


### PR DESCRIPTION
This pull will add the following (only for **VRCNowPlaying**):

* Detection of the user's current VRChat world (using VRChat logfile parsing)
* A list of worlds (by worldid and friendly name) to silence VRCNowPlaying in
* A mechanism to automatically suspend updating the chatbox if the user is in a blacklisted world

This comes in response to the community's disdain to users utilizing constantly updating chatboxes in certain environments.

For now, I only will be adding **music venue worlds** to the blacklist, and the blacklist will only affect **VRCNowPlaying** (VRCSubs, more of an accessibility tool, should be okay in these environments.)

This pull is WIP as I currently don't have a comprehensive list of worlds to blacklist VRCNowPlaying from quite yet, and I'm also wanting to collect feedback. (Please submit me music venue worlds to add to the list!)

I also don't plan on making this a config.yml option just yet. If a user is really set on using VRCNP in a blacklisted world, they can revert the code changes manually.